### PR TITLE
removed :live_client, use convention of environment names

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,17 +78,16 @@ end
 
 ## Configuration
 
-Mockingbird uses HTTPoison as default for HTTP calls in `:prod` environment,
-but you can create or customise your live client. You can either specify this
-globally at config level:
+Mockingbird uses HTTPoison as default for HTTP calls when key for current
+environment is not set in `use`. You can create or customise your default client. You can either specify this globally at config level:
 
 ```elixir
 # config/config.exs
 config :mockingbird,
-  prod: MyApp.CustomHttpClient
+  default_client: MyApp.CustomHttpClient
 ```
 
-Or on a consumer basis:
+Or on a consumer basis for specific environments:
 
 ```elixir
 # lib/my_app/git.ex

--- a/lib/mockingbird.ex
+++ b/lib/mockingbird.ex
@@ -63,9 +63,9 @@ defmodule Mockingbird do
 
       defp http_client do
         receive do
-          {:force_client_env, env} -> Map.get(@clients, env) || default_client(opts)
+          {:force_client_env, env} -> Map.get(@clients, env) || default_client()
         after
-          0 -> Map.get(@clients, Mix.env) || default_client(opts)
+          0 -> Map.get(@clients, Mix.env) || default_client()
         end
       end
 
@@ -85,7 +85,7 @@ defmodule Mockingbird do
     end
   end
 
-  defp default_client(opts) do
+  defp default_client() do
     Map.get(@clients, :default_client) || Application.get_env(:mockingbird, :default_client, @default_fallback_client)
   end
 end

--- a/lib/mockingbird.ex
+++ b/lib/mockingbird.ex
@@ -52,7 +52,6 @@ defmodule Mockingbird do
     with a client that performs calls through HTTPoison.
   """
 
-  @deafult_fallback_client Mockingbird.HTTPoisonHttpClient
 
   @doc false
   defmacro __using__(opts) do
@@ -60,6 +59,7 @@ defmodule Mockingbird do
 
     quote do
       @clients unquote(clients |> Macro.escape)
+      @deafult_fallback_client Mockingbird.HTTPoisonHttpClient
 
       defp http_client do
         receive do
@@ -67,6 +67,10 @@ defmodule Mockingbird do
         after
           0 -> Map.get(@clients, Mix.env) || default_client()
         end
+      end
+
+      defp default_client() do
+        Map.get(@clients, :default_client) || Application.get_env(:mockingbird, :default_client, @default_fallback_client)
       end
 
       def with_client(env, do: block) do
@@ -83,9 +87,5 @@ defmodule Mockingbird do
     else
       opts
     end
-  end
-
-  defp default_client() do
-    Map.get(@clients, :default_client) || Application.get_env(:mockingbird, :default_client, @default_fallback_client)
   end
 end

--- a/lib/mockingbird.ex
+++ b/lib/mockingbird.ex
@@ -81,7 +81,7 @@ defmodule Mockingbird do
   end
 
   defp clients(opts) do
-    Keyword.has_key?(opts, :client) do
+    if Keyword.has_key?(opts, :client) do
       []
       |> Keyword.put(:default_client,  Keyword.get(opts, :client))
     else


### PR DESCRIPTION
* Instead of having special key "live_client", let's make it clearly mirror app environment
* All attributes of the module are now treated as environment names
* Generalised `with_client` helper to allow any environment to apply
* If environment is not set in `use`, it uses eaither `:client` attribute, or if that is not set, fallbacks to config `:default_client` and then to the `HTTPoison` client